### PR TITLE
Add warning if cached client id doesn't match that in KACHERY_CLOUD_DIR

### DIFF
--- a/kachery_cloud/init.py
+++ b/kachery_cloud/init.py
@@ -1,6 +1,7 @@
 import os
 import socket
 import urllib.parse
+import logging
 
 from kachery_cloud.get_kachery_cloud_dir import get_kachery_cloud_dir
 
@@ -26,6 +27,10 @@ def get_client_info():
         The response dict from the Kachery Gateway
     """
     if _global_init['client_info'] != 0:
+        if _global_init['client_info']["client"]["clientId"] != get_client_id():
+            logging.warning("Client ID in current `KACHERY_CLOUD_DIR`, does not match cached client info. \n"
+                            + "If experiencing issues, please restart your python session and register the client again "
+                            + f"with `KACHERY_CLOUD_DIR` set to {os.getenv('KACHERY_CLOUD_DIR')}")
         return _global_init['client_info']
     client_id = get_client_id()
     kachery_zone = os.environ.get('KACHERY_ZONE', 'default')


### PR DESCRIPTION
Resolves #25 

- Logs a warning if cached value in `_global_init` does not match returned value from `get_client_id()`
- Helps in debugging when user has initialized and cached `_global_init` from one directory, and user code has altered `KACHERY_CLOUD_DIR` to a new unregistered location